### PR TITLE
LICENSE: fix copyright attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2022-2023, Redis, inc.
+Copyright (c) 2024-present, valkey-py contributors
+All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Attribute copyright to all valkey-py contributors.